### PR TITLE
Adjust for faker >= 2.0

### DIFF
--- a/lib/json_schema/faker/formats.rb
+++ b/lib/json_schema/faker/formats.rb
@@ -16,7 +16,7 @@ class JsonSchema::Faker
     def email(schema, hint: nil, position: nil)
       raise "invalid schema given" unless schema.format == "email"
 
-      (hint && hint[:example]) || ::Faker::Internet.safe_email
+      (hint && hint[:example]) || ::Faker::Internet.email
     end
 
     # https://tools.ietf.org/html/rfc2606
@@ -53,7 +53,7 @@ class JsonSchema::Faker
       raise "invalid schema given" unless schema.format == "uri"
 
       # TODO: urn
-      (hint && hint[:example]) || ::Faker::Internet.url(safe_domain)
+      (hint && hint[:example]) || ::Faker::Internet.url(host: safe_domain)
     end
 
     protected def safe_domain


### PR DESCRIPTION
Adjustments for newer faker gem. This also solves #17. 

cf. https://github.com/faker-ruby/faker/blob/245812bbce487bcee08d5f251c327546d87e6091/CHANGELOG.md

- for faker >= 2.0
    - `Faker::Internet.url(host = nil, path = nil, scheme = nil)` becomes `Faker::Internet.url(host: nil, path: nil, scheme: nil)`
- for faker >= 3.2.0
    - `Faker::Internet.safe_email`, and `Faker::Internet.free_email` have been deprecated. Users have until October 2023 to make the necessary changes.